### PR TITLE
Return JSON object for http errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,13 +75,20 @@ module.exports = function(path, verb, config, p, body) {
                 responseText = responseText.substring(config.skipResponsePrefixLength);
             }
             if (this.readyState === 4) {
+                try {
+                    responseText = JSON.parse(responseText);
+                } catch (e) {
+                    // response was not JSON formatted
+                }
                 if (this.status >= 200 && this.status < 400) {
-                    resolve(JSON.parse(responseText));
+                    resolve(responseText);
                 } else {
                     reject({
-                        status: this.status,
-                        statusText: this.statusText,
-                        responseText: responseText
+                        status: {
+                            code: this.status,
+                            status: this.statusText
+                        },
+                        response: responseText
                     });
                 }
             }

--- a/index.js
+++ b/index.js
@@ -78,7 +78,11 @@ module.exports = function(path, verb, config, p, body) {
                 if (this.status >= 200 && this.status < 400) {
                     resolve(JSON.parse(responseText));
                 } else {
-                    reject(this.status + ': ' + this.statusText);
+                    reject({
+                        status: this.status,
+                        statusText: this.statusText,
+                        responseText: responseText
+                    });
                 }
             }
         };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-xhr",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Simple Ajax Client for GRPC Gateway",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
For our api, the error can be 
```
HTTP Error (HTTP status != 200):
msg = {
    status: {
    	code: '500',
    	status: 'Server Internal Error',
    }
}
API Error (HTTP status == 200):
msg = {
    status: {
    	code: '1',
    	status: 'FAILED',
    	message: 'Cluster creation failed'
    },
}
```

For Tiller api, the error will be like below:
```
// HTTP error or API Error
msg = {
    status: {
    	code: '500',
    	status: 'Server Internal Error',
    },
    response: {
	  error: "incompatible versions client:  server: v2.3.0",
	  code: 2
	}
}
```